### PR TITLE
Introduce a pc-i440fx preference

### DIFF
--- a/common-clusterpreferences-bundle.yaml
+++ b/common-clusterpreferences-bundle.yaml
@@ -23,6 +23,17 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha1
 kind: VirtualMachineClusterPreference
 metadata:
+  name: centos.7.i440fx
+spec:
+  devices:
+    preferredDiskBus: virtio
+    preferredInterfaceModel: virtio
+  machine:
+    preferredMachineType: pc
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachineClusterPreference
+metadata:
   name: centos.8
 spec:
   devices:
@@ -136,6 +147,17 @@ spec:
     preferredInputBus: virtio
     preferredInputType: tablet
     preferredInterfaceModel: virtio
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachineClusterPreference
+metadata:
+  name: rhel.7.i440fx
+spec:
+  devices:
+    preferredDiskBus: virtio
+    preferredInterfaceModel: virtio
+  machine:
+    preferredMachineType: pc
 ---
 apiVersion: instancetype.kubevirt.io/v1alpha1
 kind: VirtualMachineClusterPreference

--- a/common-clusterpreferences-bundle.yaml
+++ b/common-clusterpreferences-bundle.yaml
@@ -23,6 +23,9 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha1
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    description: |
+      pc-i440fx is deprecated and will be removed in a future release.
   name: centos.7.i440fx
 spec:
   devices:
@@ -122,6 +125,9 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha1
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    description: |
+      pc-i440fx is deprecated and will be removed in a future release.
   name: pc-i440fx
 spec:
   machine:
@@ -151,6 +157,9 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha1
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    description: |
+      pc-i440fx is deprecated and will be removed in a future release.
   name: rhel.7.i440fx
 spec:
   devices:

--- a/common-clusterpreferences-bundle.yaml
+++ b/common-clusterpreferences-bundle.yaml
@@ -111,6 +111,14 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha1
 kind: VirtualMachineClusterPreference
 metadata:
+  name: pc-i440fx
+spec:
+  machine:
+    preferredMachineType: pc
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachineClusterPreference
+metadata:
   name: rhel.7
 spec:
   devices:

--- a/common-instancetypes-all-bundle.yaml
+++ b/common-instancetypes-all-bundle.yaml
@@ -116,6 +116,9 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha1
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    description: |
+      pc-i440fx is deprecated and will be removed in a future release.
   name: centos.7.i440fx
 spec:
   devices:
@@ -215,6 +218,9 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha1
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    description: |
+      pc-i440fx is deprecated and will be removed in a future release.
   name: pc-i440fx
 spec:
   machine:
@@ -244,6 +250,9 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha1
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    description: |
+      pc-i440fx is deprecated and will be removed in a future release.
   name: rhel.7.i440fx
 spec:
   devices:
@@ -885,6 +894,9 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha1
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    description: |
+      pc-i440fx is deprecated and will be removed in a future release.
   name: centos.7.i440fx
 spec:
   devices:
@@ -984,6 +996,9 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha1
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    description: |
+      pc-i440fx is deprecated and will be removed in a future release.
   name: pc-i440fx
 spec:
   machine:
@@ -1013,6 +1028,9 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha1
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    description: |
+      pc-i440fx is deprecated and will be removed in a future release.
   name: rhel.7.i440fx
 spec:
   devices:

--- a/common-instancetypes-all-bundle.yaml
+++ b/common-instancetypes-all-bundle.yaml
@@ -116,6 +116,17 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha1
 kind: VirtualMachineClusterPreference
 metadata:
+  name: centos.7.i440fx
+spec:
+  devices:
+    preferredDiskBus: virtio
+    preferredInterfaceModel: virtio
+  machine:
+    preferredMachineType: pc
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachineClusterPreference
+metadata:
   name: centos.8
 spec:
   devices:
@@ -229,6 +240,17 @@ spec:
     preferredInputBus: virtio
     preferredInputType: tablet
     preferredInterfaceModel: virtio
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachineClusterPreference
+metadata:
+  name: rhel.7.i440fx
+spec:
+  devices:
+    preferredDiskBus: virtio
+    preferredInterfaceModel: virtio
+  machine:
+    preferredMachineType: pc
 ---
 apiVersion: instancetype.kubevirt.io/v1alpha1
 kind: VirtualMachineClusterPreference
@@ -863,6 +885,17 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha1
 kind: VirtualMachinePreference
 metadata:
+  name: centos.7.i440fx
+spec:
+  devices:
+    preferredDiskBus: virtio
+    preferredInterfaceModel: virtio
+  machine:
+    preferredMachineType: pc
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachinePreference
+metadata:
   name: centos.8
 spec:
   devices:
@@ -976,6 +1009,17 @@ spec:
     preferredInputBus: virtio
     preferredInputType: tablet
     preferredInterfaceModel: virtio
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachinePreference
+metadata:
+  name: rhel.7.i440fx
+spec:
+  devices:
+    preferredDiskBus: virtio
+    preferredInterfaceModel: virtio
+  machine:
+    preferredMachineType: pc
 ---
 apiVersion: instancetype.kubevirt.io/v1alpha1
 kind: VirtualMachinePreference

--- a/common-instancetypes-all-bundle.yaml
+++ b/common-instancetypes-all-bundle.yaml
@@ -204,6 +204,14 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha1
 kind: VirtualMachineClusterPreference
 metadata:
+  name: pc-i440fx
+spec:
+  machine:
+    preferredMachineType: pc
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachineClusterPreference
+metadata:
   name: rhel.7
 spec:
   devices:
@@ -939,6 +947,14 @@ spec:
   firmware:
     preferredUseEfi: true
     preferredUseSecureBoot: true
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachinePreference
+metadata:
+  name: pc-i440fx
+spec:
+  machine:
+    preferredMachineType: pc
 ---
 apiVersion: instancetype.kubevirt.io/v1alpha1
 kind: VirtualMachinePreference

--- a/common-instancetypes/preferences/centos/7_i440fx/kustomization.yaml
+++ b/common-instancetypes/preferences/centos/7_i440fx/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../7
+
+nameSuffix: ".i440fx"
+
+components:
+  - ../../components/machinetype-pc-i440fx

--- a/common-instancetypes/preferences/centos/kustomization.yaml
+++ b/common-instancetypes/preferences/centos/kustomization.yaml
@@ -6,5 +6,6 @@ resources:
   - ./9
   - ./8_desktop
   - ./8
+  - ./7_i440fx
   - ./7_desktop
   - ./7

--- a/common-instancetypes/preferences/components/machinetype-pc-i440fx/kustomization.yaml
+++ b/common-instancetypes/preferences/components/machinetype-pc-i440fx/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: ./machinetype-pc-i440fx.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./machinetype-pc-i440fx.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/common-instancetypes/preferences/components/machinetype-pc-i440fx/machinetype-pc-i440fx.yaml
+++ b/common-instancetypes/preferences/components/machinetype-pc-i440fx/machinetype-pc-i440fx.yaml
@@ -3,6 +3,9 @@ apiVersion: instancetype.kubevirt.io/v1alpha1
 kind: VirtualMachinePreference
 metadata:
   name: machinetype-pc-i440fx
+  annotations:
+    description: |
+      pc-i440fx is deprecated and will be removed in a future release.
 spec:
   machine:
     preferredMachineType: pc

--- a/common-instancetypes/preferences/components/machinetype-pc-i440fx/machinetype-pc-i440fx.yaml
+++ b/common-instancetypes/preferences/components/machinetype-pc-i440fx/machinetype-pc-i440fx.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachinePreference
+metadata:
+  name: machinetype-pc-i440fx
+spec:
+  machine:
+    preferredMachineType: pc

--- a/common-instancetypes/preferences/kustomization.yaml
+++ b/common-instancetypes/preferences/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./centos
   - ./ubuntu
   - ./fedora
+  - ./pc-i440fx

--- a/common-instancetypes/preferences/pc-i440fx/kustomization.yaml
+++ b/common-instancetypes/preferences/pc-i440fx/kustomization.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+
+components:
+  - ../components/machinetype-pc-i440fx
+
+patches:
+  - target:
+      kind: VirtualMachinePreference
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: pc-i440fx
+  - target:
+      kind: VirtualMachineClusterPreference
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: pc-i440fx

--- a/common-instancetypes/preferences/rhel/7_i440fx/kustomization.yaml
+++ b/common-instancetypes/preferences/rhel/7_i440fx/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../7
+
+nameSuffix: ".i440fx"
+
+components:
+  - ../../components/machinetype-pc-i440fx

--- a/common-instancetypes/preferences/rhel/kustomization.yaml
+++ b/common-instancetypes/preferences/rhel/kustomization.yaml
@@ -6,5 +6,6 @@ resources:
   - ./9
   - ./8_desktop
   - ./8
+  - ./7_i440fx
   - ./7_desktop
   - ./7

--- a/common-preferences-bundle.yaml
+++ b/common-preferences-bundle.yaml
@@ -23,6 +23,9 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha1
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    description: |
+      pc-i440fx is deprecated and will be removed in a future release.
   name: centos.7.i440fx
 spec:
   devices:
@@ -122,6 +125,9 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha1
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    description: |
+      pc-i440fx is deprecated and will be removed in a future release.
   name: pc-i440fx
 spec:
   machine:
@@ -151,6 +157,9 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha1
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    description: |
+      pc-i440fx is deprecated and will be removed in a future release.
   name: rhel.7.i440fx
 spec:
   devices:

--- a/common-preferences-bundle.yaml
+++ b/common-preferences-bundle.yaml
@@ -111,6 +111,14 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha1
 kind: VirtualMachinePreference
 metadata:
+  name: pc-i440fx
+spec:
+  machine:
+    preferredMachineType: pc
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachinePreference
+metadata:
   name: rhel.7
 spec:
   devices:

--- a/common-preferences-bundle.yaml
+++ b/common-preferences-bundle.yaml
@@ -23,6 +23,17 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha1
 kind: VirtualMachinePreference
 metadata:
+  name: centos.7.i440fx
+spec:
+  devices:
+    preferredDiskBus: virtio
+    preferredInterfaceModel: virtio
+  machine:
+    preferredMachineType: pc
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachinePreference
+metadata:
   name: centos.8
 spec:
   devices:
@@ -136,6 +147,17 @@ spec:
     preferredInputBus: virtio
     preferredInputType: tablet
     preferredInterfaceModel: virtio
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachinePreference
+metadata:
+  name: rhel.7.i440fx
+spec:
+  devices:
+    preferredDiskBus: virtio
+    preferredInterfaceModel: virtio
+  machine:
+    preferredMachineType: pc
 ---
 apiVersion: instancetype.kubevirt.io/v1alpha1
 kind: VirtualMachinePreference


### PR DESCRIPTION
**What this PR does / why we need it**:

As suggested by existing downstream templates some users might want to
run their workloads using an older machinetype than q35. This change
introduces an example preference using the older pc-i440fx machinetype.

[1] https://github.com/RHsyseng/cnv-supplemental-templates/blob/main/templates/pc-i440fx/generic-server-large-pc-i440fx.yaml

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
